### PR TITLE
Fix ServiceListener typing in example_zeroconf.py

### DIFF
--- a/example_zeroconf.py
+++ b/example_zeroconf.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 
-from zeroconf import ServiceBrowser, Zeroconf
+from zeroconf import ServiceBrowser, ServiceListener, Zeroconf
 
 
-class MyListener:
+class MyListener(ServiceListener):
     def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
         pass
 
-    def remove_service(self, zeroconf, type, name):
+    def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
         print("Service %s removed" % (name,))
 
-    def add_service(self, zeroconf, type, name):
-        info = zeroconf.get_service_info(type, name)
+    def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        info = zc.get_service_info(type_, name)
         print("Service %s added, service info: %s" % (name, info))
 
 


### PR DESCRIPTION
## Summary
- `MyListener` in `example_zeroconf.py` did not inherit from `zeroconf`'s `ServiceListener` and had untyped/incorrectly named parameters, causing a Pylance `reportArgumentType` error when passed to `ServiceBrowser`.

## Changes
- Import and subclass `ServiceListener` explicitly (it's a plain base class, not a `typing.Protocol`, so structural typing alone doesn't satisfy the type checker).
- Add matching type annotations to `add_service` and `remove_service` to align with `update_service`.